### PR TITLE
addition of new blom grids 

### DIFF
--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -98,7 +98,7 @@
     <category>setup</category>
     <group>setup_nml</group>
     <desc>
-      Restart file format. 
+      Restart file format.
     </desc>
     <valid_values>default</valid_values>
     <values>
@@ -469,7 +469,10 @@
       <value hgrid="tx0.1v2">tripole</value>
       <value hgrid="tx0.1v3">tripole</value>
       <value hgrid="tx1v1">tripole</value>
+      <value hgrid="tnx2v1">tripole</value>
       <value hgrid="tnx1v4">tripole</value>
+      <value hgrid="tnx0.25v4">tripole</value>
+      <value hgrid="tnx0.125v4">tripole</value>
       <value hgrid="ar9v3">regional</value>
       <value hgrid="ar9v4">regional</value>
       <value cice_mode="prescribed">rectangular</value>
@@ -532,9 +535,12 @@
       <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/horiz_grid_200709.ieeer8</value>
       <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/horiz_grid_200709.ieeer8</value>
       <value hgrid="tx1v1">$DIN_LOC_ROOT/ocn/pop/tx1v1/grid/horiz_grid_20050510.ieeer8</value>
+      <value hgrid="tnx2v1">$DIN_LOC_ROOT/ocn/blom/grid/horiz_grid_tnx2v1_20130206.ieeer8</value>
       <value hgrid="tnx1v4">$DIN_LOC_ROOT/ocn/blom/grid/horiz_grid_tnx1v4_20170622.ieeer8</value>
-      <value hgrid="ar9v3">$DIN_LOC_ROOT/ice/cice/ar9v3_20101118.grid</value>
+      <value hgrid="tnx0.25v4">$DIN_LOC_ROOT/ocn/blom/grid/horiz_grid_tnx0.25v4_20170622.ieeer8</value>
+      <value hgrid="tnx0.125v4">$DIN_LOC_ROOT/ocn/blom/grid/horiz_grid_tnx0.125v4_20200722.ieeer8</value>
       <value hgrid="ar9v4">$DIN_LOC_ROOT/ice/cice/ar9v3_20101118.grid</value>
+      <value hgrid="ar9v3">$DIN_LOC_ROOT/ice/cice/ar9v3_20101118.grid</value>
       <value hgrid="us20">$DIN_LOC_ROOT/ice/cice/domain.ocn.us20.20110426.nc</value>
     </values>
   </entry>
@@ -548,7 +554,7 @@
       input file for CICE grid info
     </desc>
     <values>
-      <value>UNSET</value> 
+      <value>UNSET</value>
       <value hgrid="gx1v6">$DIN_LOC_ROOT/ocn/pop/gx1v6/grid/topography_20090204.ieeei4</value>
       <value hgrid="gx1v7">$DIN_LOC_ROOT/ocn/pop/gx1v7/grid/topography_20161215.ieeei4</value>
       <value hgrid="tx0.66v1">$DIN_LOC_ROOT/ocn/mom/tx0.66v1/grid/topography_20190315.ieeei4</value>
@@ -556,7 +562,10 @@
       <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/topography_200709.ieeei4</value>
       <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/topography_20170718.ieeei4</value>
       <value hgrid="tx1v1">$DIN_LOC_ROOT/ocn/pop/tx1v1/grid/topography_20050510.ieeei4</value>
+      <value hgrid="tnx2v1">$DIN_LOC_ROOT/ocn/blom/grid/topography_tnx2v1_20130206.ieeei4</value>
       <value hgrid="tnx1v4">$DIN_LOC_ROOT/ocn/blom/grid/topography_tnx1v4_20170622.ieeei4</value>
+      <value hgrid="tnx0.25v4">$DIN_LOC_ROOT/ocn/blom/grid/topography_tnx0.25v4_20170622.ieeei4</value>
+      <value hgrid="tnx0.125v4">$DIN_LOC_ROOT/ocn/blom/grid/topography_tnx0.125v4_20200722.ieeei4</value>
       <value hgrid="ar9v3">$DIN_LOC_ROOT/ocn/pop/ar9v3/grid/kmt.ar9v3.ocn.ChanBarrier.20100622.ieeei4</value>
       <value hgrid="ar9v4">$DIN_LOC_ROOT/ice/cice/ar9v3_20110106.kmt</value>
       <value hgrid="us20">$DIN_LOC_ROOT/ice/cice/domain.ocn.us20.20110426.nc</value>
@@ -872,7 +881,10 @@
       <value hgrid ='tx0.1v2'>tripole</value>
       <value hgrid ='tx0.1v3'>tripole</value>
       <value hgrid ='tx1v1'>tripole</value>
+      <value hgrid ='tnx2v1'>tripole</value>
       <value hgrid ='tnx1v4'>tripole</value>
+      <value hgrid ='tnx0.25v4'>tripole</value>
+      <value hgrid ='tnx0.125v4'>tripole</value>
     </values>
   </entry>
 
@@ -2366,7 +2378,7 @@
       minimum value of ocean friction velocity
     </desc>
     <values>
-      <value>0.005</value> 
+      <value>0.005</value>
     </values>
   </entry>
 
@@ -2441,7 +2453,7 @@
       Longwave emissivity
     </desc>
     <values>
-      <value>0.95d0</value> 
+      <value>0.95d0</value>
     </values>
   </entry>
 
@@ -2453,7 +2465,7 @@
        reference salinity for fluxes
     </desc>
     <values>
-      <value>4.0d0</value> 
+      <value>4.0d0</value>
     </values>
   </entry>
 


### PR DESCRIPTION
Addition to support the following blom grids:
hgrid ='tnx2v1',  hgrid ='tnx0.25v4',  hgrid ='tnx0.125v4'

Ran the following tests:
SMS_D_Ld3.T62_tn21.NOINY.betzy_intel
