### PR TITLE
set distribution type to sectrobin for tx1 grid

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -178,7 +178,11 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
     if not "max_blocks" in user_nl:
         nmlgen.set_value('max_blocks', value=cice_mxblcks)
     if not "distribution_type" in user_nl:
-        nmlgen.set_value('distribution_type', value=cice_decomptype)
+        if 'tnx1' in hgrid:
+            print ("  RESETTING distribution_type to sectrobin ")
+            nmlgen.set_value('distribution_type', value='sectrobin')
+        else:
+            nmlgen.set_value('distribution_type', value=cice_decomptype)
     if not "processor_shape" in user_nl:
         nmlgen.set_value('processor_shape', value=cice_decompsetting)
 
@@ -245,7 +249,7 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
         cice_ptr = cice_ptr.replace("_0001", inst_string)
         if os.path.exists(os.path.join(rundir, cice_ptr)):
             nmlgen.set_value('pointer_file', cice_ptr)
-            
+
     #----------------------------------------------------
     # Write out namelist groups
     #----------------------------------------------------


### PR DESCRIPTION
This PR sets distribution_type='sectrobin' for all tx1 gries grids and resolves #12.

NOTE: - the issue noted in #12 does not occur with all PE model settings. In particular, it gets triggered when CICE is asked to run with 1024 tasks. However, it seems to run fine with 1920 tasks - and a spacecurve distribution type. The comment below from @JensBDebernard applied when the model was crashing with 1024 tasks.

Testing: I have verified that  following case:
`./create_newcase --case test_cice_sectrobin --compset N1850 --res ne30pg3_tn14 --project nn9560k --machine betzy --compiler intel --pecount=L --run-unsupported`
gives identical performance and bfb answers if 
`distribution_type = "sectrobin` or `distribution_type = "spacecurve`.
Both these distribution types work for the case where NTASKS_ICE=1920.