### PR TITLE
Update CICE source code to cice6_6_0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/NorESMhub/CICE
-        fxtag = cice6_6_0_20250522_noresm
-        fxrequired = AlwaysRequired
-        fxDONOTUSEurl = https://github.com/ESCOMP/CICE
+	fxtag = cice6_6_0_20250522_noresm
+	fxrequired = AlwaysRequired
+	fxDONOTUSEurl = https://github.com/ESCOMP/CICE

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/NorESMhub/CICE
-        fxtag = cice6_5_0_20240702_noresm_v2
+        fxtag = cice6_6_0_20250522_noresm
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -274,6 +274,7 @@
       <value>m,x,x,x,x</value>
       <value hgrid="ar9v3">m,d,h,x,x</value>
       <value hgrid="ar9v4">m,d,h,x,x</value>
+      <value cice_mode="prescribed">m,x,x,x,x</value>
     </values>
   </entry>
 
@@ -547,7 +548,7 @@
       <value hgrid="gx1v7">$DIN_LOC_ROOT/ocn/pop/gx1v7/grid/horiz_grid_20010402.ieeer8</value>
       <value hgrid="gx3v7">$DIN_LOC_ROOT/ocn/pop/gx3v7/grid/horiz_grid_20030806.ieeer8</value>
       <value hgrid="tx0.66v1">$DIN_LOC_ROOT/ocn/mom/tx0.66v1/grid/horiz_grid_20190315.ieeer8</value>
-      <value hgrid="tx2_3v2">/glade/work/gmarques/cesm/tx2_3/seaice_files/horiz_grid_20230416.ieeer8</value>
+      <value hgrid="tx2_3v2">$DIN_LOC_ROOT/ocn/mom/tx2_3v2/horiz_grid_20230416.ieeer8</value>
       <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/horiz_grid_200709.ieeer8</value>
       <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/horiz_grid_200709.ieeer8</value>
       <value hgrid="tx1v1">$DIN_LOC_ROOT/ocn/pop/tx1v1/grid/horiz_grid_20050510.ieeer8</value>
@@ -556,8 +557,8 @@
       <value hgrid="tnx0.5v1">$DIN_LOC_ROOT/ocn/blom/grid/horiz_grid_tnx0.5v1_20240702.ieeei8</value>
       <value hgrid="tnx0.25v4">$DIN_LOC_ROOT/ocn/blom/grid/horiz_grid_tnx0.25v4_20170622.ieeer8</value>
       <value hgrid="tnx0.125v4">$DIN_LOC_ROOT/ocn/blom/grid/horiz_grid_tnx0.125v4_20221013.ieeer8</value>
-      <value hgrid="ar9v4">$DIN_LOC_ROOT/ice/cice/ar9v3_20101118.grid</value>
       <value hgrid="ar9v3">$DIN_LOC_ROOT/ice/cice/ar9v3_20101118.grid</value>
+      <value hgrid="ar9v4">$DIN_LOC_ROOT/ice/cice/ar9v3_20101118.grid</value>
       <value hgrid="us20">$DIN_LOC_ROOT/ice/cice/domain.ocn.us20.20110426.nc</value>
     </values>
   </entry>
@@ -575,7 +576,7 @@
       <value hgrid="gx1v6">$DIN_LOC_ROOT/ocn/pop/gx1v6/grid/topography_20090204.ieeei4</value>
       <value hgrid="gx1v7">$DIN_LOC_ROOT/ocn/pop/gx1v7/grid/topography_20161215.ieeei4</value>
       <value hgrid="tx0.66v1">$DIN_LOC_ROOT/ocn/mom/tx0.66v1/grid/topography_20190315.ieeei4</value>
-      <value hgrid="tx2_3v2">/glade/work/gmarques/cesm/tx2_3/seaice_files/topography_20230416.ieeei4</value>
+      <value hgrid="tx2_3v2">$DIN_LOC_ROOT/ocn/mom/tx2_3v2/topography_20230416.ieeei4</value>
       <value hgrid="gx3v7">$DIN_LOC_ROOT/ocn/pop/gx3v7/grid/topography_20100105.ieeei4</value>
       <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/topography_200709.ieeei4</value>
       <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/topography_20170718.ieeei4</value>
@@ -1199,6 +1200,30 @@
     <group>tracer_nml</group>
     <desc>
       Pond lvl restart from file.
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
+  <entry id="tr_pond_sealvl">
+    <type>logical</type>
+    <category>tracers</category>
+    <group>tracer_nml</group>
+    <desc>
+      Sea level pond tracer.
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
+  <entry id="restart_pond_sealvl">
+    <type>logical</type>
+    <category>tracers</category>
+    <group>tracer_nml</group>
+    <desc>
+      Sea level pond restart from file.
     </desc>
     <values>
       <value>.false.</value>
@@ -2104,7 +2129,19 @@
       aspect ratio of pond changes (depth:area)
     </desc>
     <values>
-      <value> 0.8 </value>
+      <value> 0.8d0 </value>
+    </values>
+  </entry>
+
+  <entry id="tscale_pnd_drain">
+    <type>real</type>
+    <category>parameterizations</category>
+    <group>ponds_nml</group>
+    <desc>
+      time scale for macroscopic pond drainage
+    </desc>
+    <values>
+      <value> 0.5d0 </value>
     </values>
   </entry>
 
@@ -2423,7 +2460,7 @@
       minimum value of ocean friction velocity
     </desc>
     <values>
-      <value>0.005</value>
+      <value>0.005</value> 
     </values>
   </entry>
 
@@ -2539,6 +2576,19 @@
     </values>
   </entry>
 
+  <entry id="congel_freeze">
+    <type>char</type>
+    <category>forcing</category>
+    <group>forcing_nml</group>
+    <desc>
+      One step or two step congelation growth
+    </desc>
+    <valid_values>one-step,two-step</valid_values>
+    <values>
+      <value>one-step</value>
+    </values>
+  </entry>
+
   <entry id="saltflux_option">
     <type>char</type>
     <category>forcing</category>
@@ -2572,7 +2622,7 @@
     <desc>
       How waves are specified.
     </desc>
-    <valid_values>none,profile,constant,random</valid_values>
+    <valid_values>none,profile,constant,random,alt</valid_values>
     <values>
       <value>none</value>
     </values>
@@ -3675,7 +3725,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -3688,7 +3738,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -3701,7 +3751,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -3993,7 +4043,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4021,7 +4071,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4049,7 +4099,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4076,7 +4126,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4810,6 +4860,162 @@
   </entry>
 
   <entry id="f_apeff_ai">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_flpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_expnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_frpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_rfpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_ilpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_mipnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_rdpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_flpndn">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_expndn">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_frpndn">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_rfpndn">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_ilpndn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>

--- a/cime_config/testdefs/testlist_cice.xml
+++ b/cime_config/testdefs/testlist_cice.xml
@@ -174,4 +174,47 @@
     </machines>
   </test>
 
+  <!-- ========================== -->
+  <!-- NorESM TEST                -->
+  <!-- Test with OMIP experiments -->
+  <!-- ========================== -->
+
+  <test name="SMS_D_Ld1" grid="T62_tn14" compset="NOINY">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_cice_noresm"/>
+      <machine name="betzy" compiler="gnu" category="aux_cice_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">debug mode; 1 degree; hybrid coordinates; IAF forcing</option>
+    </options>
+  </test>
+  <test name="ERS_Ld3" grid="T62_tn21" compset="NOINY">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_cice_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">00:20:00</option>
+      <option name="comment">restart test; 2 degree; hybrid coordinates; core forcing</option>
+    </options>
+  </test>
+  <test name="ERS_Ld3" grid="TL319_tn05" compset="NOIIAJRA">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_cice_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+      <option name="comment">restart test; 0.5 degree; hybrid coordinates; JRA forcing</option>
+    </options>
+  </test>
+  <test name="ERI" grid="TL319_tn14" compset="NOIIAJRAOC">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_cice_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+      <option name="comment">hybrid/branch/restart test; 1 degree; hybrid coordinates; hamocc; JRA forcing</option>
+    </options>
+  </test>
+
 </testlist>

--- a/cime_config/testdefs/testlist_cice.xml
+++ b/cime_config/testdefs/testlist_cice.xml
@@ -207,7 +207,7 @@
       <option name="comment">restart test; 0.5 degree; hybrid coordinates; JRA forcing</option>
     </options>
   </test>
-  <test name="ERI" grid="TL319_tn14" compset="NOIIAJRAOC">
+  <test name="ERI" grid="TL319_tn14" compset="NOIIAJRA">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cice_noresm"/>
     </machines>


### PR DESCRIPTION
This PR aims to prepare NorESM_CICE for `noresm3_0_beta01`.

- [x] Update CICE source code to cice_6_6_0 (#11)
  - Tag: [cice6_6_0_20250522_noresm](https://github.com/NorESMhub/CICE/releases/tag/cice6_6_0_20250522_noresm)
  - Commit: [62ffbaa](https://github.com/NorESMhub/CICE/commit/62ffbaad39e5d3799f4798c11686cbf5a574d8f8)
- [x] Include new tests for CICE (#14)
- [x] Run test suite for CICE

Suggest tag name: `noresm_cice6_6_0_20250522_v0`