### PR TITLE
Namelist changes to turn on sealvl ponds, and advanced snow physics 

### DIFF
--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -1187,7 +1187,7 @@
       Pond lvl tracer.
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
       <value phys="cice4">.false.</value>
       <value hgrid="ar9v3">.true.</value>
       <value hgrid="ar9v4">.true.</value>
@@ -1214,7 +1214,7 @@
       Sea level pond tracer.
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -1310,7 +1310,7 @@
       Snow tracers
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -1818,9 +1818,9 @@
     <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
-      shortwave method, 'default' ('ccsm3') or 'dEdd'
+      shortwave method, 'default' ('ccsm3') 'dEdd' or 'dEdd_ad'
     </desc>
-    <valid_values>default,dEdd</valid_values>
+    <valid_values>default,dEdd,dEdd_ad</valid_values>
     <values>
       <value>dEdd</value>
     </values>
@@ -2026,6 +2026,20 @@
     </values>
   </entry>
 
+  <entry id="snw_ssp_table">
+    <type>char</type>
+    <category>parameterizations</category>
+    <group>shortwave_nml</group>
+    <desc>
+      snow radiative properties (only used with dEdd_ad)
+    </desc>
+    <valid_values>test,snicar</valid_values>
+    <values>
+      <value>test</value>
+    </values>
+  </entry>
+
+  
   <!-- =========================== -->
   <!-- ponds_nml -->
   <!-- =========================== -->
@@ -2087,7 +2101,7 @@
     </desc>
     <valid_values>hlid,cesm</valid_values>
     <values>
-      <value>cesm</value>
+      <value>hlid</value>
       <value hgrid="ar9v3"> hlid </value>
       <value hgrid="ar9v4"> hlid </value>
     </values>
@@ -2158,7 +2172,7 @@
     </desc>
     <valid_values>none,bulk,snwITDrdg</valid_values>
     <values>
-      <value>none</value>
+      <value>snwITDrdg</value>
     </values>
   </entry>
 
@@ -2170,7 +2184,7 @@
       Snow grain
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -2182,7 +2196,7 @@
       Pond liquid
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -2527,6 +2541,21 @@
   <!--   </values> -->
   <!-- </entry> -->
 
+
+  <entry id="calc_dragio">
+    <type>logical</type>
+    <category>forcing</category>
+    <group>forcing_nml</group>
+    <desc>
+      Explicit calculation of ice-ocean drag based on the upper ocean
+      layer thickness 
+    </desc>
+    <values>
+      <value>.false</value>
+    </values>
+  </entry>
+
+  
   <entry id="emissivity">
     <type>real</type>
     <category>forcing</category>
@@ -3397,7 +3426,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
     </values>
   </entry>
 
@@ -4801,7 +4830,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4853,7 +4882,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>


### PR DESCRIPTION
Namelist changes to activate recommended sealvl melt ponds instead of lvl ponds in cice6_6. 
Also advanced snow physics and snow radiation is enabled. 

A discussion of how to further modify and test these settings are given in 
https://github.com/NorESMhub/noresm3_dev_simulations/discussions/169



