### PR TITLE
Corrected snow redistribution keyword. Changed to 'none' as default

### DIFF
--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -2170,9 +2170,9 @@
     <desc>
       snow redistribution
     </desc>
-    <valid_values>none,bulk,snwITDrdg</valid_values>
+    <valid_values>none,bulk,ITDrdg</valid_values>
     <values>
-      <value>snwITDrdg</value>
+      <value>bulk</value>
     </values>
   </entry>
 
@@ -3426,7 +3426,7 @@
     <desc>
     </desc>
     <values>
-      <value>mdxxx</value>
+      <value>mdhxx</value>
     </values>
   </entry>
 
@@ -4514,7 +4514,7 @@
     <desc>
     </desc>
     <values>
-      <value>mdhxx</value>
+      <value>mxxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4528,7 +4528,7 @@
     <desc>
     </desc>
     <values>
-      <value>mdhxx</value>
+      <value>mxxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4542,7 +4542,7 @@
     <desc>
     </desc>
     <values>
-      <value>mdhxx</value>
+      <value>mxxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -2172,7 +2172,7 @@
     </desc>
     <valid_values>none,bulk,ITDrdg</valid_values>
     <values>
-      <value>bulk</value>
+      <value>none</value>
     </values>
   </entry>
 


### PR DESCRIPTION
Corrected the wrong snow redistribution keyword from snwITDrdg to ITDrdg. 
Changed default value to snwredist='bulk' due to aerosol conservation problem when ITDrdg was used. 

P.S. snwITDrdg is not a valid value in CICE, and the model behaves as if snwredist='none' was used. 

Small changes in default variable list for high-frequency output. (daily, hourly)
