### PR TITLE
update NorESM_CICE to CESM_CICE/cesm3 cice6 6 1 6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_6_0_20250106
+        fxtag = cice6_6_0_20250220
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_5_0_20240702
+        fxtag = cice6_5_0_20240820
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_6_0_20241120
+        fxtag = cice6_6_0_20250106
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_6_0_20250428
+        fxtag = cice6_6_0_20250429
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_5_0_20241030
+        fxtag = cice6_5_0_20241108
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_5_0_20241008
+        fxtag = cice6_5_0_20241009
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_6_0_20250429
+        fxtag = cice6_6_1_20250724
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_5_0_20241108
+        fxtag = cice6_6_0_20241120
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_5_0_20240820
+        fxtag = cice6_5_0_20240920
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_5_0_20241028
+        fxtag = cice6_5_0_20241030
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_5_0_20241025
+        fxtag = cice6_5_0_20241028
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_6_0_20250220
+        fxtag = cice6_6_0_20250318
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_6_0_20250318
+        fxtag = cice6_6_0_20250428
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_5_0_20241009
+        fxtag = cice6_5_0_20241025
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_5_0_20240920
+        fxtag = cice6_5_0_20241008
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/ESCOMP/CICE
-        fxtag = cice6_6_1_20250724
+        fxtag = cice6_6_1_20250909
         fxrequired = AlwaysRequired
         fxDONOTUSEurl = https://github.com/ESCOMP/CICE
         

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import os, shutil, sys, glob, imp
+import os, shutil, sys, glob
 
 CIMEROOT = os.environ.get("CIMEROOT")
 if CIMEROOT is None:

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -243,9 +243,15 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
     if drv_ptr:
         cice_ptr = drv_ptr.replace("cpl","ice")
         cice_ptr = cice_ptr.replace("_0001", inst_string)
-        if os.path.exists(os.path.join(rundir, cice_ptr)):
-            nmlgen.set_value('pointer_file', cice_ptr)
-            
+    else:
+        # find the most recent file matching pattern
+        pattern = "rpointer.ice*"
+        files = glob.glob(pattern, root_dir=rundir)
+        files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
+        cice_ptr = files[-1]
+    if os.path.exists(os.path.join(rundir, cice_ptr)):
+        nmlgen.set_value('pointer_file', cice_ptr)
+
     #----------------------------------------------------
     # Write out namelist groups
     #----------------------------------------------------

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -247,8 +247,9 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
         # find the most recent file matching pattern
         cice_ptr = None
         pattern = "rpointer.ice*"
-        files = glob.glob(pattern, root_dir=rundir)
-        files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
+        with chdir(rundir):
+            files = glob.glob(pattern)
+            files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
         if files:
             cice_ptr = files[-1]
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -245,11 +245,14 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
         cice_ptr = cice_ptr.replace("_0001", inst_string)
     else:
         # find the most recent file matching pattern
+        cice_ptr = None
         pattern = "rpointer.ice*"
         files = glob.glob(pattern, root_dir=rundir)
         files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
-        cice_ptr = files[-1]
-    if os.path.exists(os.path.join(rundir, cice_ptr)):
+        if files:
+            cice_ptr = files[-1]
+
+    if cice_ptr and os.path.exists(os.path.join(rundir, cice_ptr)):
         nmlgen.set_value('pointer_file', cice_ptr)
 
     #----------------------------------------------------

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -9,7 +9,7 @@
 # Disable these because this is our standard setup
 # pylint: disable=wildcard-import,unused-wildcard-import,wrong-import-position
 
-import os, shutil, sys, glob, filecmp, imp, re
+import os, shutil, sys, glob, filecmp, re
 
 CIMEROOT = os.environ.get("CIMEROOT")
 if CIMEROOT is None:

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -212,7 +212,7 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
         run_refcase = case.get_value("RUN_REFCASE")
         run_refdate = case.get_value("RUN_REFDATE")
         run_tod     = case.get_value("RUN_REFTOD")
-        ice_ic = "%s.cice.r.%s-%s.nc" %(run_refcase, run_refdate, run_tod)
+        ice_ic = "%s.cice%s.r.%s-%s.nc" %(run_refcase, inst_string, run_refdate, run_tod)
         nmlgen.add_default("ice_ic", value=ice_ic, ignore_abs_path=True)
     else:
         nmlgen.add_default("ice_ic")

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -221,7 +221,7 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
 
     # error checks for prescribed ice mode
     if cice_mode == 'prescribed':
-        sstice_grid_filename = case.get_value('SSTICE_GRID_FILENAME')
+        sstice_grid_filename = case.get_value('SSTICE_MESH_FILENAME')
         sstice_data_filename = case.get_value('SSTICE_DATA_FILENAME')
         sstice_year_align = case.get_value('SSTICE_YEAR_ALIGN')
         sstice_year_start = case.get_value('SSTICE_YEAR_START')

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -247,9 +247,10 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
         # find the most recent file matching pattern
         cice_ptr = None
         pattern = "rpointer.ice*"
-        with chdir(rundir):
-            files = glob.glob(pattern)
-            files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
+        os.chdir(rundir)
+        files = glob.glob(pattern)
+        files.sort(key=lambda x: os.path.getmtime(os.path.join(rundir,x)))
+        os.chdir(case.get_case_root())
         if files:
             cice_ptr = files[-1]
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
 ####################################################################################
-def _create_namelists(case, confdir, infile, nmlgen):
+def _create_namelists(case, confdir, infile, nmlgen, inst_string):
 ####################################################################################
 
     """Write out the namelist for this component.
@@ -237,6 +237,15 @@ def _create_namelists(case, confdir, infile, nmlgen):
         if sstice_year_end== 'UNSET':
             expect(False,  "%s must be set for cice prescribed mode" %sstice_year_end)
 
+    # Set timestamp pointer file
+    rundir = case.get_value("RUNDIR")
+    drv_ptr = case.get_value("DRV_RESTART_POINTER")
+    if drv_ptr:
+        cice_ptr = drv_ptr.replace("cpl","ice")
+        cice_ptr = cice_ptr.replace("_0001", inst_string)
+        if os.path.exists(os.path.join(rundir, cice_ptr)):
+            nmlgen.set_value('pointer_file', cice_ptr)
+            
     #----------------------------------------------------
     # Write out namelist groups
     #----------------------------------------------------
@@ -338,7 +347,7 @@ def buildnml(case, caseroot, compname):
         namelist_infile = [infile]
 
         # create namelist
-        _create_namelists(case, confdir, namelist_infile, nmlgen)
+        _create_namelists(case, confdir, namelist_infile, nmlgen, inst_string)
 
         # copy namelist files to rundir
         if os.path.isdir(rundir):

--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -5,11 +5,13 @@
     <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
-      <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>
+      <rpointer_file>rpointer.ice$NINST_STRING.$DATENAME</rpointer_file>
       <rpointer_content>./$CASE.cice$NINST_STRING.r.$DATENAME.nc</rpointer_content>
     </rpointer>
     <test_file_names>
-      <tfile disposition="copy">rpointer.ice</tfile>
+      <tfile disposition="copy">rpointer.ice.1976-01-01-00000</tfile>
+      <tfile disposition="ignore">rpointer.ice.1976-01-01-08320</tfile>
+      <tfile disposition="copy">rpointer.ice_9999.1976-01-01-00000</tfile>
       <tfile disposition="copy">casename.cice.r.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.cice.h.1976-01-01-00000.nc</tfile>
     </test_file_names>

--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -10,7 +10,6 @@
     </rpointer>
     <test_file_names>
       <tfile disposition="copy">rpointer.ice.1976-01-01-00000</tfile>
-      <tfile disposition="ignore">rpointer.ice.1976-01-01-08320</tfile>
       <tfile disposition="copy">rpointer.ice_9999.1976-01-01-00000</tfile>
       <tfile disposition="copy">casename.cice.r.1976-01-01-00000.nc</tfile>
       <tfile disposition="move">casename.cice.h.1976-01-01-00000.nc</tfile>

--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -2,7 +2,8 @@
 
   <comp_archive_spec compname="cice" compclass="ice">
     <rest_file_extension>[ri]</rest_file_extension>
-    <hist_file_extension>h\d*.*\.nc$</hist_file_extension>
+    <hist_file_extension>h\d*.*\.nc(\.gz)?$</hist_file_extension>
+    <hist_file_extension>e</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.ice$NINST_STRING</rpointer_file>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -40,17 +40,17 @@
 
   <compset>
     <alias>D</alias>
-    <lname>2000_DATM%JRA_SLND_CICE_DOCN%SOM_DROF%JRA_SGLC_SWAV</lname>
+    <lname>2000_DATM%JRA-RYF9091_SLND_CICE_DOCN%SOM_DROF%JRA-RYF9091_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>DIAF</alias>
-    <lname>2000_DATM%IAF_SLND_CICE_DOCN%SOM_DROF%IAF_SGLC_SWAV</lname>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_CICE_DOCN%SOM_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>DTEST</alias>
-    <lname>2000_DATM%JRA_SLND_CICE_DOCN%SOM_DROF%JRA_SGLC_SWAV_TEST</lname>
+    <lname>2000_DATM%JRA-RYF9091_SLND_CICE_DOCN%SOM_DROF%JRA-RYF9091_SGLC_SWAV_TEST</lname>
   </compset>
 
 </compsets>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -40,7 +40,7 @@
 
   <compset>
     <alias>D</alias>
-    <lname>2000_DATM%NYF_SLND_CICE_DOCN%SOM_DROF%NYF_SGLC_SWAV</lname>
+    <lname>2000_DATM%JRA_SLND_CICE_DOCN%SOM_DROF%JRA_SGLC_SWAV</lname>
   </compset>
 
   <compset>
@@ -50,7 +50,7 @@
 
   <compset>
     <alias>DTEST</alias>
-    <lname>2000_DATM%NYF_SLND_CICE_DOCN%SOM_DROF%NYF_SGLC_SWAV_TEST</lname>
+    <lname>2000_DATM%JRA_SLND_CICE_DOCN%SOM_DROF%JRA_SGLC_SWAV_TEST</lname>
   </compset>
 
 </compsets>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -111,6 +111,42 @@
       </pes>
     </mach>
   </grid>
+  <grid name="oi%tx2">
+    <mach name="any">
+      <pes pesize="any" compset="any">
+	<ntasks>
+	  <ntasks_atm>-4</ntasks_atm> 
+	  <ntasks_lnd>-4</ntasks_lnd>
+	  <ntasks_rof>-4</ntasks_rof> 
+	  <ntasks_ice>-4</ntasks_ice> 
+	  <ntasks_ocn>-4</ntasks_ocn> 
+	  <ntasks_glc>-4</ntasks_glc> 
+	  <ntasks_wav>-4</ntasks_wav>
+	  <ntasks_cpl>-4</ntasks_cpl> 	
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>2</nthrds_atm> 
+	  <nthrds_lnd>2</nthrds_lnd> 
+	  <nthrds_rof>2</nthrds_rof> 
+	  <nthrds_ice>2</nthrds_ice> 
+	  <nthrds_ocn>2</nthrds_ocn> 
+	  <nthrds_glc>2</nthrds_glc> 
+	  <nthrds_wav>2</nthrds_wav> 
+	  <nthrds_cpl>2</nthrds_cpl> 
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm>
+	  <rootpe_lnd>0</rootpe_lnd> 
+	  <rootpe_rof>0</rootpe_rof>
+	  <rootpe_ice>0</rootpe_ice>
+	  <rootpe_ocn>0</rootpe_ocn>
+	  <rootpe_glc>0</rootpe_glc>
+	  <rootpe_wav>0</rootpe_wav>
+	  <rootpe_cpl>0</rootpe_cpl>
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
   <grid name="oi%gx1">
     <mach name="any">
       <pes pesize="any" compset="any">

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -309,7 +309,7 @@
       frequency of restart output (once per 1,h,d,m,y)
     </desc>
     <values>
-      <value>x,x,x,x,x</value>
+      <value>y,x,x,x,x</value>
     </values>
   </entry>
 
@@ -1179,6 +1179,30 @@
     <group>tracer_nml</group>
     <desc>
       Pond lvl restart from file.
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
+  <entry id="tr_pond_sealvl">
+    <type>logical</type>
+    <category>tracers</category>
+    <group>tracer_nml</group>
+    <desc>
+      Sea level pond tracer.
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
+  <entry id="restart_pond_sealvl">
+    <type>logical</type>
+    <category>tracers</category>
+    <group>tracer_nml</group>
+    <desc>
+      Sea level pond restart from file.
     </desc>
     <values>
       <value>.false.</value>
@@ -2084,7 +2108,19 @@
       aspect ratio of pond changes (depth:area)
     </desc>
     <values>
-      <value> 0.8 </value>
+      <value> 0.8d0 </value>
+    </values>
+  </entry>
+
+  <entry id="tscale_pnd_drain">
+    <type>real</type>
+    <category>parameterizations</category>
+    <group>ponds_nml</group>
+    <desc>
+      time scale for macroscopic pond drainage
+    </desc>
+    <values>
+      <value> 0.5d0 </value>
     </values>
   </entry>
 
@@ -2519,6 +2555,19 @@
     </values>
   </entry>
 
+  <entry id="congel_freeze">
+    <type>char</type>
+    <category>forcing</category>
+    <group>forcing_nml</group>
+    <desc>
+      One step or two step congelation growth
+    </desc>
+    <valid_values>one-step,two-step</valid_values>
+    <values>
+      <value>two-step</value>
+    </values>
+  </entry>
+
   <entry id="saltflux_option">
     <type>char</type>
     <category>forcing</category>
@@ -2552,7 +2601,7 @@
     <desc>
       How waves are specified.
     </desc>
-    <valid_values>none,profile,constant,random</valid_values>
+    <valid_values>none,profile,constant,random,alt</valid_values>
     <values>
       <value>none</value>
     </values>
@@ -4797,6 +4846,162 @@
     </desc>
     <values>
       <value>mxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_flpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_expnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_frpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_rfpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_ilpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_mipnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_rdpnd">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_flpndn">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_expndn">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_frpndn">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_rfpndn">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_ilpndn">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>xxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -542,7 +542,7 @@
       <value hgrid="gx1v7">$DIN_LOC_ROOT/ocn/pop/gx1v7/grid/horiz_grid_20010402.ieeer8</value>
       <value hgrid="gx3v7">$DIN_LOC_ROOT/ocn/pop/gx3v7/grid/horiz_grid_20030806.ieeer8</value>
       <value hgrid="tx0.66v1">$DIN_LOC_ROOT/ocn/mom/tx0.66v1/grid/horiz_grid_20190315.ieeer8</value>
-      <value hgrid="tx2_3v2">/glade/work/gmarques/cesm/tx2_3/seaice_files/horiz_grid_20230416.ieeer8</value>
+      <value hgrid="tx2_3v2">$DIN_LOC_ROOT/ocn/mom/tx2_3v2/horiz_grid_20230416.ieeer8</value>
       <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/horiz_grid_200709.ieeer8</value>
       <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/horiz_grid_200709.ieeer8</value>
       <value hgrid="tx1v1">$DIN_LOC_ROOT/ocn/pop/tx1v1/grid/horiz_grid_20050510.ieeer8</value>
@@ -565,7 +565,7 @@
       <value hgrid="gx1v6">$DIN_LOC_ROOT/ocn/pop/gx1v6/grid/topography_20090204.ieeei4</value>
       <value hgrid="gx1v7">$DIN_LOC_ROOT/ocn/pop/gx1v7/grid/topography_20161215.ieeei4</value>
       <value hgrid="tx0.66v1">$DIN_LOC_ROOT/ocn/mom/tx0.66v1/grid/topography_20190315.ieeei4</value>
-      <value hgrid="tx2_3v2">/glade/work/gmarques/cesm/tx2_3/seaice_files/topography_20230416.ieeei4</value>
+      <value hgrid="tx2_3v2">$DIN_LOC_ROOT/ocn/mom/tx2_3v2/topography_20230416.ieeei4</value>
       <value hgrid="gx3v7">$DIN_LOC_ROOT/ocn/pop/gx3v7/grid/topography_20100105.ieeei4</value>
       <value hgrid="tx0.1v2">$DIN_LOC_ROOT/ocn/pop/tx0.1v2/grid/topography_200709.ieeei4</value>
       <value hgrid="tx0.1v3">$DIN_LOC_ROOT/ocn/pop/tx0.1v3/grid/topography_20170718.ieeei4</value>

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -1166,7 +1166,7 @@
       Pond lvl tracer.
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
       <value phys="cice4">.false.</value>
       <value hgrid="ar9v3">.true.</value>
       <value hgrid="ar9v4">.true.</value>
@@ -1193,7 +1193,7 @@
       Sea level pond tracer.
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -1423,7 +1423,7 @@
       solid fraction at lower boundary between 0 and 1
     </desc>
     <values>
-      <value>0.85</value>
+      <value>0.45</value>
     </values>
   </entry>
 
@@ -2066,7 +2066,7 @@
     </desc>
     <valid_values>hlid,cesm</valid_values>
     <values>
-      <value>cesm</value>
+      <value>hlid</value>
       <value hgrid="ar9v3"> hlid </value>
       <value hgrid="ar9v4"> hlid </value>
     </values>
@@ -2080,7 +2080,7 @@
       minimum melt water added to ponds
     </desc>
     <values>
-      <value>0.15</value>
+      <value>1.0</value>
       <value hgrid="ar9v3"> 0.15 </value>
       <value hgrid="ar9v4"> 0.15 </value>
     </values>
@@ -2094,7 +2094,7 @@
       maximum melt water added to ponds
     </desc>
     <values>
-      <value>0.85</value>
+      <value>1.0</value>
       <value hgrid="ar9v3"> 1.00 </value>
       <value hgrid="ar9v4"> 1.00 </value>
     </values>
@@ -4832,7 +4832,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4845,7 +4845,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -4699,7 +4699,7 @@
     <desc>
     </desc>
     <values>
-      <value>mdxxx</value>
+      <value>xxxxx</value>
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -511,7 +511,7 @@
     </desc>
     <valid_values>A,B,C</valid_values>
     <values>
-      <value>C</value>
+      <value>B</value>
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -271,7 +271,7 @@
       frequency of history output (once per 1,h,d,m,y)
     </desc>
     <values>
-      <value>m,x,x,x,x</value>
+      <value>m,d,x,x,x</value>
       <value hgrid="ar9v3">m,d,h,x,x</value>
       <value hgrid="ar9v4">m,d,h,x,x</value>
     </values>
@@ -285,7 +285,7 @@
       frequency of history output (10 = once per 10 h,d,m,y)
     </desc>
     <values>
-      <value>1,0,0,0,0</value>
+      <value>1,1,0,0,0</value>
     </values>
   </entry>
 
@@ -309,7 +309,7 @@
       frequency of restart output (once per 1,h,d,m,y)
     </desc>
     <values>
-      <value>y,x,x,x,x</value>
+      <value>x,x,x,x,x</value>
     </values>
   </entry>
 
@@ -511,7 +511,7 @@
     </desc>
     <valid_values>A,B,C</valid_values>
     <values>
-      <value>B</value>
+      <value>C</value>
     </values>
   </entry>
 
@@ -1166,7 +1166,7 @@
       Pond lvl tracer.
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
       <value phys="cice4">.false.</value>
       <value hgrid="ar9v3">.true.</value>
       <value hgrid="ar9v4">.true.</value>
@@ -1193,7 +1193,7 @@
       Sea level pond tracer.
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -1289,7 +1289,7 @@
       Snow tracers
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -2066,7 +2066,7 @@
     </desc>
     <valid_values>hlid,cesm</valid_values>
     <values>
-      <value>cesm</value>
+      <value>hlid</value>
       <value hgrid="ar9v3"> hlid </value>
       <value hgrid="ar9v4"> hlid </value>
     </values>
@@ -2080,7 +2080,7 @@
       minimum melt water added to ponds
     </desc>
     <values>
-      <value> 0.15 </value>
+      <value>1.0</value>
       <value hgrid="ar9v3"> 0.15 </value>
       <value hgrid="ar9v4"> 0.15 </value>
     </values>
@@ -2094,7 +2094,7 @@
       maximum melt water added to ponds
     </desc>
     <values>
-      <value> 0.85 </value>
+      <value>1.0</value>
       <value hgrid="ar9v3"> 1.00 </value>
       <value hgrid="ar9v4"> 1.00 </value>
     </values>
@@ -2137,7 +2137,7 @@
     </desc>
     <valid_values>none,bulk,snwITDrdg</valid_values>
     <values>
-      <value>none</value>
+      <value>snwITDrdg</value>
     </values>
   </entry>
 
@@ -2564,7 +2564,7 @@
     </desc>
     <valid_values>one-step,two-step</valid_values>
     <values>
-      <value>two-step</value>
+      <value>one-step</value>
     </values>
   </entry>
 
@@ -3270,7 +3270,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mnxxx</value>
     </values>
   </entry>
 
@@ -3376,7 +3376,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
     </values>
   </entry>
 
@@ -3704,7 +3704,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -3717,7 +3717,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -3730,7 +3730,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -3926,7 +3926,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4008,7 +4008,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4022,7 +4022,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4036,7 +4036,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4050,7 +4050,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4506,7 +4506,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4699,7 +4699,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
     </values>
   </entry>
 
@@ -4714,7 +4714,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4728,7 +4728,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4741,7 +4741,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4754,7 +4754,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4780,7 +4780,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4858,7 +4858,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4871,7 +4871,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4884,7 +4884,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4897,7 +4897,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4910,7 +4910,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4923,7 +4923,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4936,7 +4936,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4949,7 +4949,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4962,7 +4962,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4975,7 +4975,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4988,7 +4988,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5001,7 +5001,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5074,7 +5074,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -5088,7 +5088,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5101,7 +5101,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5114,7 +5114,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5127,7 +5127,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5140,7 +5140,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5153,7 +5153,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5166,7 +5166,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -553,6 +553,20 @@
     </values>
   </entry>
 
+  <entry id="kmt_type">
+    <type>char</type>
+    <category>grid</category>
+    <group>grid_nml</group>
+    <desc>
+      type of grid
+    </desc>
+    <valid_values>none,file</valid_values>
+    <values>
+      <value>file</value>
+      <value cice_mode="prescribed">none</value>
+    </values>
+  </entry>
+
   <entry id="kmt_file">
     <type>char</type>
     <category>grid</category>

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -274,6 +274,7 @@
       <value>m,d,x,x,x</value>
       <value hgrid="ar9v3">m,d,h,x,x</value>
       <value hgrid="ar9v4">m,d,h,x,x</value>
+      <value cice_mode="prescribed">m,x,x,x,x</value>
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -1166,7 +1166,7 @@
       Pond lvl tracer.
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
       <value phys="cice4">.false.</value>
       <value hgrid="ar9v3">.true.</value>
       <value hgrid="ar9v4">.true.</value>
@@ -1193,7 +1193,7 @@
       Sea level pond tracer.
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
     </values>
   </entry>
 
@@ -2066,7 +2066,7 @@
     </desc>
     <valid_values>hlid,cesm</valid_values>
     <values>
-      <value>hlid</value>
+      <value>cesm</value>
       <value hgrid="ar9v3"> hlid </value>
       <value hgrid="ar9v4"> hlid </value>
     </values>
@@ -2080,7 +2080,7 @@
       minimum melt water added to ponds
     </desc>
     <values>
-      <value>1.0</value>
+      <value>0.15</value>
       <value hgrid="ar9v3"> 0.15 </value>
       <value hgrid="ar9v4"> 0.15 </value>
     </values>
@@ -2094,7 +2094,7 @@
       maximum melt water added to ponds
     </desc>
     <values>
-      <value>1.0</value>
+      <value>0.85</value>
       <value hgrid="ar9v3"> 1.00 </value>
       <value hgrid="ar9v4"> 1.00 </value>
     </values>

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -4852,7 +4852,7 @@
     </values>
   </entry>
 
-  <entry id="f_flpnd">
+  <entry id="f_dpnd_flush">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4865,7 +4865,7 @@
     </values>
   </entry>
 
-  <entry id="f_expnd">
+  <entry id="f_dpnd_expon">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4878,7 +4878,7 @@
     </values>
   </entry>
 
-  <entry id="f_frpnd">
+  <entry id="f_dpnd_freebd">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4891,7 +4891,7 @@
     </values>
   </entry>
 
-  <entry id="f_rfpnd">
+  <entry id="f_dpnd_initial">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4904,7 +4904,7 @@
     </values>
   </entry>
 
-  <entry id="f_ilpnd">
+  <entry id="f_dpnd_dlid">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4917,7 +4917,7 @@
     </values>
   </entry>
 
-  <entry id="f_mipnd">
+  <entry id="f_dpnd_melt">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4930,7 +4930,7 @@
     </values>
   </entry>
 
-  <entry id="f_rdpnd">
+  <entry id="f_dpnd_ridge">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4943,7 +4943,7 @@
     </values>
   </entry>
 
-  <entry id="f_flpndn">
+  <entry id="f_dpnd_flushn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4956,7 +4956,7 @@
     </values>
   </entry>
 
-  <entry id="f_expndn">
+  <entry id="f_dpnd_exponn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4969,7 +4969,7 @@
     </values>
   </entry>
 
-  <entry id="f_frpndn">
+  <entry id="f_dpnd_freebdn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4982,7 +4982,7 @@
     </values>
   </entry>
 
-  <entry id="f_rfpndn">
+  <entry id="f_dpnd_initialn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4995,7 +4995,7 @@
     </values>
   </entry>
 
-  <entry id="f_ilpndn">
+  <entry id="f_dpnd_dlidn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>

--- a/cime_config/testdefs/testlist_cice.xml
+++ b/cime_config/testdefs/testlist_cice.xml
@@ -50,6 +50,11 @@
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
+  <test name="ERI_C2" grid="T62_g17" compset="DTEST" testmods="cice/default">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_cice"/>
+    </machines>
+  </test>
 
   <!-- ================= -->
   <!-- G TEST -->

--- a/cime_config/testdefs/testlist_cice.xml
+++ b/cime_config/testdefs/testlist_cice.xml
@@ -14,7 +14,7 @@
       <machine name="derecho" compiler="gnu" category="prebeta"/>
     </machines>
   </test>
-  <test name="ERP" grid="ne30pg3_t232" compset="DTEST" testmods="cice/default">
+  <test name="ERP" grid="TL319_t232" compset="DTEST" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
@@ -27,7 +27,7 @@
       <machine name="derecho" compiler="intel" category="aux_cime_baselines"/>
     </machines>
   </test>
-  <test name="ERS_IOP_Ld5" grid="ne30pg3_t232" compset="DTEST" testmods="cice/default">
+  <test name="ERS_IOP_Ld5" grid="TL319_t232" compset="DTEST" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="prebeta"/>
     </machines>
@@ -55,32 +55,32 @@
   <!-- G TEST -->
   <!-- ================= -->
 
-  <test name="ERS_Lm3" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
+  <test name="ERS_Lm3" grid="TL319_t232" compset="G_JRA" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
-  <test name="ERI" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
+  <test name="ERI" grid="TL319_t232" compset="G_JRA" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
-  <test name="PET" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
+  <test name="PET" grid="TL319_t232" compset="G_JRA" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
-  <test name="ERS" grid="TL319_t232" compset="G1850MARBL_JRA" testmods="mom/bcompset">
+  <test name="ERS" grid="TL319_t232" compset="G1850MARBL_JRA" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
 
-  <test name="ERI" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
+  <test name="ERI" grid="TL319_t232" compset="G_JRA" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
@@ -88,21 +88,21 @@
     </machines>
   </test>
 
-  <test name="ERS" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
+  <test name="ERS" grid="TL319_t232" compset="G_JRA" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="gnu" category="aux_cice"/>
       <machine name="derecho" compiler="gnu" category="prealpha"/>
     </machines>
   </test>
 
-  <test name="ERS" grid="TL319_g17" compset="G1850MARBL_JRA" testmods="mom/bcompset">
+  <test name="ERS" grid="TL319_g17" compset="G1850MARBL_JRA" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
 
-  <test name="ERS_Ld5" grid="TL319_g17" compset="G_IAF" testmods="mom/bcompset">
+  <test name="ERS_Ld5" grid="TL319_g17" compset="G_IAF" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>

--- a/cime_config/testdefs/testlist_cice.xml
+++ b/cime_config/testdefs/testlist_cice.xml
@@ -95,14 +95,14 @@
     </machines>
   </test>
 
-  <test name="ERS" grid="TL319_g17" compset="G1850MARBL_JRA" testmods="cice/default">
+  <test name="ERS" grid="TL319_t232" compset="G1850MARBL_JRA" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
 
-  <test name="ERS_Ld5" grid="TL319_g17" compset="G_IAF" testmods="cice/default">
+  <test name="ERS_Ld5" grid="TL319_t232" compset="G_IAF" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>

--- a/cime_config/testdefs/testlist_cice.xml
+++ b/cime_config/testdefs/testlist_cice.xml
@@ -139,7 +139,7 @@
       <machine name="mira" compiler="ibm" category="prebeta"/>
     </machines>
   </test>
-  <test name="ERS_Ld5" grid="f19_g17" compset="E1850TEST" testmods="cice/default">
+  <test name="ERS_D_Ld5" grid="f19_g17" compset="E1850TEST" testmods="cice/default">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
       <machine name="izumi" compiler="nag" category="prealpha"/>

--- a/cime_config/testdefs/testlist_cice.xml
+++ b/cime_config/testdefs/testlist_cice.xml
@@ -5,51 +5,46 @@
   <!-- D TEST -->
   <!-- ================= -->
 
-  <test name="ERI" grid="T62_g17" compset="DTEST" testmods="cice/default">
+  <test name="ERI" grid="TL319_t232" compset="DTEST" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel" category="aux_cime_baselines"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
-    </machines>
-  </test>
-  <test name="ERI" grid="f19_g17_rx1" compset="DTEST" testmods="cice/default">
-    <machines>
       <machine name="izumi" compiler="intel" category="prealpha"/>
       <machine name="derecho" compiler="gnu" category="prebeta"/>
     </machines>
   </test>
-  <test name="ERP" grid="f19_g17_rx1" compset="DTEST" testmods="cice/default">
+  <test name="ERP" grid="ne30pg3_t232" compset="DTEST" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
-  <test name="ERS_D_Ld5" grid="T62_g17" compset="DTEST" testmods="cice/default">
+  <test name="ERS_D_Ld5" grid="TL319_t232" compset="DTEST" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
       <machine name="derecho" compiler="intel" category="aux_cime_baselines"/>
     </machines>
   </test>
-  <test name="ERS_IOP_Ld5" grid="f19_g17_rx1" compset="DTEST" testmods="cice/default">
+  <test name="ERS_IOP_Ld5" grid="ne30pg3_t232" compset="DTEST" testmods="cice/default">
     <machines>
-      <machine name="janus" compiler="intel" category="prebeta"/>
       <machine name="derecho" compiler="intel" category="prebeta"/>
     </machines>
   </test>
-  <test name="ERS_Ld5" grid="T62_g17" compset="DTEST" testmods="cice/default">
+  <test name="ERS_Ld5" grid="TL319_t232" compset="DTEST" testmods="cice/default">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
       <machine name="hopper" compiler="pgi" category="prebeta"/>
     </machines>
   </test>
-  <test name="ERS_Ld5" grid="T62_t061" compset="DTEST" testmods="cice/default">
+  <test name="ERS_Ld5" grid="TL319_t232" compset="DTEST" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
-  <test name="PET_Ld2" grid="T62_g17" compset="DTEST" testmods="cice/default">
+  <test name="PET_Ld2" grid="TL319_t232" compset="DTEST" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
@@ -60,32 +55,32 @@
   <!-- G TEST -->
   <!-- ================= -->
 
-  <test name="ERS_Lm3" grid="T62_g37" compset="G" testmods="pop/cice">
+  <test name="ERS_Lm3" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
-  <test name="ERI" grid="f19_g17_rx1" compset="G" testmods="pop/cice">
+  <test name="ERI" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
-  <test name="PET" grid="f19_g17_rx1" compset="G" testmods="pop/cice">
+  <test name="PET" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
-  <test name="ERS" grid="f19_g17_rx1" compset="G1850ECO" testmods="pop/cice">
+  <test name="ERS" grid="TL319_t232" compset="G1850MARBL_JRA" testmods="mom/bcompset">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
 
-  <test name="ERI" grid="T62_g37" compset="G" testmods="pop/cice">
+  <test name="ERI" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
@@ -93,21 +88,21 @@
     </machines>
   </test>
 
-  <test name="ERS" grid="T62_g37" compset="G" testmods="pop/cice">
+  <test name="ERS" grid="TL319_t232" compset="G_JRA" testmods="mom/bcompset">
     <machines>
       <machine name="derecho" compiler="gnu" category="aux_cice"/>
       <machine name="derecho" compiler="gnu" category="prealpha"/>
     </machines>
   </test>
 
-  <test name="ERS" grid="T62_g17" compset="G1850ECO" testmods="pop/cice_ecosys">
+  <test name="ERS" grid="TL319_g17" compset="G1850MARBL_JRA" testmods="mom/bcompset">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
     </machines>
   </test>
 
-  <test name="ERS_Ld5" grid="TL319_g17" compset="GIAF_JRA" testmods="pop/5day_tavg">
+  <test name="ERS_Ld5" grid="TL319_g17" compset="G_IAF" testmods="mom/bcompset">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>
@@ -162,7 +157,7 @@
   <!-- B TEST -->
   <!-- ================= -->
 
-  <test name="ERS_Ld7" grid="f19_g17" compset="B1850" testmods="cice/pop">
+  <test name="ERS_Ld7" grid="ne30pg3_t232" compset="BLT1850" testmods="cice/default">
     <machines>
       <machine name="derecho" compiler="intel" category="aux_cice"/>
       <machine name="derecho" compiler="intel-oneapi" category="aux_cice"/>


### PR DESCRIPTION
@TomasTorsvik @JensBDebernard 
- this PR should be used instead of #20 and #19. 
- src/ uses the latest NorESM CICE tag - cice6_6_1_20251119_noresm
- however the wrapper layer now is merged to cesm3_cice6_6_1_6 (this is the tag used for the latest wrapper code for ESCOMP 

As is noted in the https://github.com/NorESMhub/CICE/pull/9 - there are differences between cice6_6_1_2025119_noresm and  ESCOMP cice6_6_1_20250909. The following summarizes these differences. 
$ git diff -w cice6_6_1_20250909 --name-only
cicecore/cicedyn/general/ice_init.F90
cicecore/cicedyn/infrastructure/io/io_pio2/ice_restart.F90
cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90

So is the wrapper layer merge to cesm3_cice6_6_1_6 the correct thing to do?