### PR TITLE
Feature/noresm cice6 6 1 20251129 v1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/NorESMhub/CICE
-	fxtag = cice6_6_0_20250522_noresm
+	fxtag = cice6_6_1_20251119_noresm
 	fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESCOMP/CICE

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -56,6 +56,9 @@ def _create_namelists(case, confdir, infile, nmlgen, inst_string):
     config['hgrid'] = hgrid
     config['cice_mode'] = cice_mode
 
+    run_type = case.get_value("RUN_TYPE")
+    config['run_type'] = run_type
+
     cice_config_opts = case.get_value('CICE_CONFIG_OPTS')
     if "cice5" in cice_config_opts:
         phys = "cice5"

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -563,6 +563,20 @@
     </values>
   </entry>
 
+  <entry id="kmt_type">
+    <type>char</type>
+    <category>grid</category>
+    <group>grid_nml</group>
+    <desc>
+      type of grid
+    </desc>
+    <valid_values>none,file</valid_values>
+    <values>
+      <value>file</value>
+      <value cice_mode="prescribed">none</value>
+    </values>
+  </entry>
+
   <entry id="kmt_file">
     <type>char</type>
     <category>grid</category>
@@ -1472,6 +1486,18 @@
     </values>
   </entry>
 
+  <entry id="floediam">
+    <type>real</type>
+    <category>parameterizations</category>
+    <group>thermo_nml</group>
+    <desc>
+      Floe diameter used in lateral melting
+    </desc>
+    <values>
+      <value>300.0</value> 
+    </values>
+  </entry>
+  
   <!-- =========================== -->
   <!-- dynamics_nml parameterizations -->
   <!-- =========================== -->
@@ -1818,9 +1844,9 @@
     <category>swrad</category>
     <group>shortwave_nml</group>
     <desc>
-      shortwave method, 'default' ('ccsm3') 'dEdd' or 'dEdd_ad'
+      shortwave method, 'default' ('ccsm3') 'dEdd' or 'dEdd_snicar_ad'
     </desc>
-    <valid_values>default,dEdd,dEdd_ad</valid_values>
+    <valid_values>default,dEdd,dEdd_snicar_ad</valid_values>
     <values>
       <value>dEdd</value>
     </values>
@@ -2212,6 +2238,45 @@
     </values>
   </entry>
 
+
+  <entry id="drsnw_min">
+    <type>real</type>
+    <category>parameterizations</category>
+    <group>snow_nml</group>
+    <desc>
+      Scaling of minimum dry snow growth rate (unitless)
+    </desc>
+    <values>
+      <value> 0.0 </value>
+    </values>
+  </entry>
+
+  <entry id="snw_growth_wet">
+    <type>real</type>
+    <category>parameterizations</category>
+    <group>snow_nml</group>
+    <desc>
+      wet metamorphism parameter (um^3/s)  1.e18 * 4.22e-13 (Oleson 2010)
+    </desc>
+    <values>
+      <value> 4.22e+5 </value>
+    </values>
+  </entry>
+
+
+  <entry id="snwliq_max">
+    <type>real</type>
+    <category>parameterizations</category>
+    <group>snow_nml</group>
+    <desc>
+      Irreducible saturation fraction for snow (0.033, Anderson 1976; 0.09-0.1 Denoth et al, 1979 and Brun 1989)
+    </desc>
+    <values>
+      <value> 0.033 </value>
+    </values>
+  </entry>
+
+  
   <entry id="rsnw_tmax">
     <type>real</type>
     <category>parameterizations</category>
@@ -3754,7 +3819,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -3767,7 +3832,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -3780,7 +3845,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -3976,7 +4041,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4072,7 +4137,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4100,7 +4165,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4128,7 +4193,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -4155,7 +4220,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4869,7 +4934,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -4895,13 +4960,13 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
   </entry>
 
-  <entry id="f_flpnd">
+  <entry id="f_dpnd_flush">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4914,7 +4979,7 @@
     </values>
   </entry>
 
-  <entry id="f_expnd">
+  <entry id="f_dpnd_expon">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4927,7 +4992,7 @@
     </values>
   </entry>
 
-  <entry id="f_frpnd">
+  <entry id="f_dpnd_freebd">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4940,7 +5005,7 @@
     </values>
   </entry>
 
-  <entry id="f_rfpnd">
+  <entry id="f_dpnd_initial">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4953,7 +5018,7 @@
     </values>
   </entry>
 
-  <entry id="f_ilpnd">
+  <entry id="f_dpnd_dlid">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4966,7 +5031,20 @@
     </values>
   </entry>
 
-  <entry id="f_mipnd">
+  <entry id="f_dpnd_melt">
+    <type>char</type>
+    <category>history</category>
+    <group>icefields_pond_nml</group>
+    <desc>
+    </desc>
+    <values>
+      <value>mdxxx</value>
+      <value hgrid="ar9v4">mdhxx</value>
+      <value cice_mode='prescribed'>xxxxx</value>
+    </values>
+  </entry>
+
+  <entry id="f_dpnd_ridge">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
@@ -4979,79 +5057,66 @@
     </values>
   </entry>
 
-  <entry id="f_rdpnd">
+  <entry id="f_dpnd_flushn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>xxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
   </entry>
 
-  <entry id="f_flpndn">
+  <entry id="f_dpnd_exponn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>xxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
   </entry>
 
-  <entry id="f_expndn">
+  <entry id="f_dpnd_freebdn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>xxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
   </entry>
 
-  <entry id="f_frpndn">
+  <entry id="f_dpnd_initialn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>xxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
   </entry>
 
-  <entry id="f_rfpndn">
+  <entry id="f_dpnd_dlidn">
     <type>char</type>
     <category>history</category>
     <group>icefields_pond_nml</group>
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
-      <value hgrid="ar9v4">mdhxx</value>
-      <value cice_mode='prescribed'>xxxxx</value>
-    </values>
-  </entry>
-
-  <entry id="f_ilpndn">
-    <type>char</type>
-    <category>history</category>
-    <group>icefields_pond_nml</group>
-    <desc>
-    </desc>
-    <values>
-      <value>mxxxx</value>
+      <value>xxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5124,7 +5189,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
       <value hgrid="ar9v3">mxxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
@@ -5138,7 +5203,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5151,7 +5216,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5164,7 +5229,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5177,7 +5242,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5190,7 +5255,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5203,7 +5268,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5216,7 +5281,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5233,7 +5298,7 @@
     <desc>
     </desc>
     <values>
-      <value>mxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5246,7 +5311,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5259,7 +5324,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>
@@ -5272,7 +5337,7 @@
     <desc>
     </desc>
     <values>
-      <value>xxxxx</value>
+      <value>mdxxx</value>
       <value hgrid="ar9v4">mdhxx</value>
       <value cice_mode='prescribed'>xxxxx</value>
     </values>

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -1110,7 +1110,6 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value run_type="branch">.true.</value>
       <value run_type="hybrid">.true.</value>
     </values>
   </entry>
@@ -1139,7 +1138,6 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value run_type="branch">.true.</value>
       <value run_type="hybrid">.true.</value>
     </values>
   </entry>
@@ -1168,7 +1166,6 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value run_type="branch">.true.</value>
       <value run_type="hybrid">.true.</value>
       
     </values>
@@ -1248,7 +1245,6 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value run_type="branch">.true.</value>
       <value run_type="hybrid">.true.</value>
     </values>
   </entry>
@@ -1274,7 +1270,6 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value run_type="branch">.true.</value>
       <value run_type="hybrid">.true.</value>
     </values>
   </entry>
@@ -1348,7 +1343,6 @@
     </desc>
     <values>
       <value>.false.</value>
-      <value run_type="branch">.true.</value>
       <value run_type="hybrid">.true.</value>
     </values>
   </entry>

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -1109,7 +1109,7 @@
       Ice age restart from file.
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -1136,7 +1136,7 @@
       FY area restart from file.
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -1163,7 +1163,7 @@
       lvl restart from file.
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -1240,7 +1240,7 @@
       Sea level pond restart from file.
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -1264,7 +1264,7 @@
       Aerosol restart from file.
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 
@@ -1336,7 +1336,7 @@
       snow restart from file
     </desc>
     <values>
-      <value>.false.</value>
+      <value>.true.</value>
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -1109,7 +1109,9 @@
       Ice age restart from file.
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
+      <value run_type="branch">.true.</value>
+      <value run_type="hybrid">.true.</value>
     </values>
   </entry>
 
@@ -1136,7 +1138,9 @@
       FY area restart from file.
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
+      <value run_type="branch">.true.</value>
+      <value run_type="hybrid">.true.</value>
     </values>
   </entry>
 
@@ -1163,7 +1167,10 @@
       lvl restart from file.
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
+      <value run_type="branch">.true.</value>
+      <value run_type="hybrid">.true.</value>
+      
     </values>
   </entry>
 
@@ -1240,7 +1247,9 @@
       Sea level pond restart from file.
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
+      <value run_type="branch">.true.</value>
+      <value run_type="hybrid">.true.</value>
     </values>
   </entry>
 
@@ -1264,7 +1273,9 @@
       Aerosol restart from file.
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
+      <value run_type="branch">.true.</value>
+      <value run_type="hybrid">.true.</value>
     </values>
   </entry>
 
@@ -1336,7 +1347,9 @@
       snow restart from file
     </desc>
     <values>
-      <value>.true.</value>
+      <value>.false.</value>
+      <value run_type="branch">.true.</value>
+      <value run_type="hybrid">.true.</value>
     </values>
   </entry>
 


### PR DESCRIPTION

- Update wrapper for the cice6_6_1_20251119_noresm tag. 
- Changes to flags for branch and hybrid runs to ensure continuous trajectories for aerosols, level/ridged ice, ice age, melt ponds, snow grain size. 
- Additional namelist variables for tuning of snow albedo.
- Changes to history names for ponds.
- More default output on daily files when these are turned on (off by default). 

- prealpha_noresm and aux_blom_noresm tests have been done. Bit identical restarts, but answer-changing compared to the noresm3_0_beta06 basis for hybrid and branch runs based on old files. Additional fields in history files, and changed namelist files. 

