### PR TITLE
Enabled ksno as namelist parameter

### DIFF
--- a/cime_config/namelist_definition_cice.xml
+++ b/cime_config/namelist_definition_cice.xml
@@ -1504,6 +1504,19 @@
       <value>300.0</value> 
     </values>
   </entry>
+
+  <entry id="ksno">
+    <type>real</type>
+    <category>parameterizations</category>
+    <group>thermo_nml</group>
+    <desc>
+      Heat conductivity of snow on ice
+    </desc>
+    <values>
+      <value>0.30</value> 
+    </values>
+  </entry>
+
   
   <!-- =========================== -->
   <!-- dynamics_nml parameterizations -->


### PR DESCRIPTION
To allow snow conductivity tuning the ksno namelist variable is enabled through the script system in NorESM_CICE. 

With same input, the model is bit-identical to earlier versions. 
This is confirmed with the aux_blom_noresm test based on noresm3_0_beta10, where only expected fails show up. 
Some of the prealpha_noresm tests fails, or use longer time than tolerated. These fails are not related to the present update. 

