### PR TITLE
Update CICE to tag cice6_6_3_20260429_noresm_v1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src"]
 	path = src
 	url = https://github.com/NorESMHub/CICE
-	fxtag = cice6_6_3_20260429_noresm_v0
+	fxtag = cice6_6_3_20260429_noresm_v1
 	fxrequired = AlwaysRequired
 	fxDONOTUSEurl = https://github.com/ESCOMP/CICE


### PR DESCRIPTION
Include update from
- https://github.com/NorESMhub/CICE/pull/13

All `aux_cice_noresm` tests PASS